### PR TITLE
Refactor the CI run to be smaller and more reusable.

### DIFF
--- a/!ReadMe
+++ b/!ReadMe
@@ -1,4 +1,4 @@
-                        LineEditor Module release 2.75
+                        LineEditor Module release 2.76
                         ==============================
 
 ** Source, binaries and documentation   **

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,32 +20,62 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Zip up the source to send to JFPaaS
-      run: zip -9 /tmp/source-archive.zip * .robuild.yml
-
-    - name: Send the file to JFPatch as a service
-      run: curl -F 'source=@/tmp/source-archive.zip' http://jfpatch.riscos.online/build/json > /tmp/output.json
-
-    - name: Show any messages
-      run: jq .output[] /tmp/output.json
-
-    - name: Check the return code
+    # Step intended to be reused in CI pipelines.
+    - name: Build through JFPatch-as-a-service
       run: |
-        rc=$(jq -r .rc /tmp/output.json)
-        echo RC: $rc
-        if [ "$rc" != "0" ] ; then
-            echo "FAILED" >&2
+        set -o pipefail
+        mkdir /tmp/robuild
+        # Zip up the source to send to robuild
+        zip -9r /tmp/source-archive.zip * .robuild.yml
+        # Send the archive file to JFPatch as a service
+        curl -q -F 'source=@/tmp/source-archive.zip' -o /tmp/robuild/result.json http://jfpatch.riscos.online/build/json
+        # Extract any sysetm messages and output
+        jq -r '.messages[]' /tmp/robuild/result.json > /tmp/robuild/messages.txt
+        jq -r 'reduce .output[] as $i ("";. + $i)' /tmp/robuild/result.json > /tmp/robuild/output.txt
+        # Extract return code
+        rc=$(jq -r .rc /tmp/robuild/result.json | tee /tmp/robuild/rc.json)
+        # Marker files for the state
+        if [ "$rc" != "0" ] ; then touch /tmp/robuild/failed ; else touch /tmp/robuild/ok ; fi
+        # Extract the built binary if we had any
+        if [ "$rc" = "0" ] ; then
+            jq -r .data /tmp/robuild/result.json | base64 --decode - > /tmp/robuild/built
+        fi
+    # Outputs:
+    #   /tmp/robuild/result.json    - JSON output from the service.
+    #   /tmp/robuild/{ok,failed}    - status of the build (whether RC was 0).
+    #   /tmp/robuild/built          - the output result from the build.
+    #   /tmp/robuild/rc             - the value of the return code (decimal string)
+    #   /tmp/robuild/messages.txt   - system messages
+    #   /tmp/robuild/output.txt     - output from the build
+
+    # Another drop in, which uses that information to show the results
+    - name: Did it work?
+      run: |
+        echo "System messages:"
+        sed 's/^/  /' < /tmp/robuild/messages.txt
+        echo
+        echo "Build output:"
+        sed 's/^/  /' < /tmp/robuild/output.txt
+        echo
+        if [ ! -f /tmp/robuild/ok ] ; then
+            echo "FAILED! Aborting"
             exit 1
         fi
 
-    - name: Extract output archive
+    - name: Give the archive a versioned name
       run: |
-        jq -r .data /tmp/output.json > /tmp/output.base64
-        base64 --decode /tmp/output.base64 > /tmp/LineEditor.zip
+        version=$(sed '/MajorVersion / ! d ; s/.*MajorVersion *"\(.*\)"/\1/' VersionNum)
+        echo This is version: $version
+        if [ -f /tmp/robuild/built ] ; then
+            cp /tmp/robuild/built "/tmp/robuild/LineEditor-$version.zip"
+        else
+            echo "No archive was built?"
+            exit 1
+        fi
 
     - uses: actions/upload-artifact@v2
       with:
         name: LineEditor
-        path: /tmp/LineEditor.zip
+        path: /tmp/robuild/LineEditor*.zip
       # The artifact that is downloadable from the Actions is actually a zip of the artifacts
       # that we supply. So it will be a regular Zip file containing a RISC OS Zip file.

--- a/LESrc,fd1
+++ b/LESrc,fd1
@@ -47,7 +47,7 @@
 47:
 48ON ERROR PROCerr:END
 49REM Need to fettle places where comments say !HACK! [case sens]
-50vsn$="2.76d (R4-patch)":date$="15 Apr 2020":REM or MID$(TIME$,5,11)
+50vsn$=FNversionnum:date$=MID$(TIME$,5,11)
 51extra$=" "
 52fnm$="LineEditor"
 53TIME=0
@@ -5199,3 +5199,17 @@
 5201DATA paste, swapchars, quote, vanilla, cup, cdown, up, down, sup, sdown
 5202DATA escape, fnkey, wipeallhistory, enter, return, uncopy
 5203DATA showcomp, completeshow, fileropen
+5220:
+5221REM Read the version number from the VersionNum file
+5222DEFFNversionnum
+5223LOCAL i%, line$, version$
+5224i%=OPENIN("VersionNum")
+5225WHILE NOT EOF#i%
+5226  line$=GET$#i%
+5227  IF LEFT$(line$, 28) = "#define Module_MajorVersion " THEN
+5228    version$=MID$(line$, INSTR(line$, """")+1)
+5229    version$=LEFT$(version$, LEN(version$)-1)
+5230  ENDIF
+5231ENDWHILE
+5232CLOSE#i%
+5233=version$

--- a/VersionNum
+++ b/VersionNum
@@ -1,0 +1,24 @@
+/* LineEditor (2.76) 22:22:55 23/5/2020
+ *
+ * This file is automatically maintained by rocommit, do not edit manually.
+ *
+ */
+#define Module_MajorVersion_CMHG        2.76
+#define Module_MinorVersion_CMHG
+#define Module_Date_CMHG                23 May 2020
+
+#define Module_MajorVersion             "2.76"
+#define Module_Version                  0
+#define Module_MinorVersion             ""
+#define Module_Date                     "23 May 2020"
+
+#define Module_ApplicationDate2         "23-May-20"
+#define Module_ApplicationDate4         "23-May-2020"
+
+#define Module_ComponentName            "LineEditor"
+#define Module_ComponentBranch          ""
+#define Module_ComponentPath            "LineEditor"
+
+#define Module_FullVersion              "2.76"
+#define Module_FullVersionAndDate       "2.76 (23 May 2020)"
+#define Module_HelpVersion              "2.76 (23 May 2020)"


### PR DESCRIPTION
The steps are now grouped together so that there's a 'build it'
step, a 'show what happened' step, and a 'put the archive in a place
that we can archive it' step. The latter step uses a VersionNum file
to give the version of the module which is appended to the archive
we produce, like most software releases do. The VersionNum is used
in the module to ensure that we keep these consistent.