### PR TITLE
Update the CI to meet GitHubs requirements; add releasing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,81 +1,107 @@
-# This is a basic workflow to help you get started with Actions
+---
+# RISC OS CI build through build.riscos.online
+#
+# To reuse this configuration with your own repository:
+#
+#   - Create a .robuild.yaml to describe what should be built on RISC OS.
+#       - `jobs.build.script` should be a list of commands to run on RISC OS
+#       - `jobs.build.artifacts.path` should be the directory to zip.
+#   - Create a VersionNum file if you wish to use the automated versioning
+#     in the same style as the RISC OS sources. [optional]
+#   - Update the 3rd step ('give the archive a versioned name') to give a
+#     suitable name for the archive.
+#   - Update the 4th step ('upload-artifacts') to include the same names.
+#
+# The 'release' job is triggered when a tag starting with a 'v' is created,
+# which will create a GitHub release for the repository with the name of the
+# version tag. The release will be a draft, and should be updated with
+# changes as you see fit.
+#
 
-name: CI
+name: RISC OS
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run. Triggers the workflow on:
+#   * push on any branch.
+#   * tag creation for tags beginning with a 'v'
 on:
   push:
-    branches: [ "*" ]
-  pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
+    tags: ["v*"]
+  # Pull request events happen on pull request state transitions, so we probably don't want this here.
+  #pull_request:
+  #  branches: ["*"]
 
 jobs:
-  build:
+  build-riscos:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      leafname: ${{ steps.version.outputs.leafname }}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
 
-    # Step intended to be reused in CI pipelines.
-    - name: Build through JFPatch-as-a-service
-      run: |
-        set -o pipefail
-        mkdir /tmp/robuild
-        # Zip up the source to send to robuild
-        zip -9r /tmp/source-archive.zip * .robuild.yml
-        # Send the archive file to JFPatch as a service
-        curl -q -F 'source=@/tmp/source-archive.zip' -o /tmp/robuild/result.json http://jfpatch.riscos.online/build/json
-        # Extract any sysetm messages and output
-        jq -r '.messages[]' /tmp/robuild/result.json > /tmp/robuild/messages.txt
-        jq -r 'reduce .output[] as $i ("";. + $i)' /tmp/robuild/result.json > /tmp/robuild/output.txt
-        # Extract return code
-        rc=$(jq -r .rc /tmp/robuild/result.json | tee /tmp/robuild/rc.json)
-        # Marker files for the state
-        if [ "$rc" != "0" ] ; then touch /tmp/robuild/failed ; else touch /tmp/robuild/ok ; fi
-        # Extract the built binary if we had any
-        if [ "$rc" = "0" ] ; then
-            jq -r .data /tmp/robuild/result.json | base64 --decode - > /tmp/robuild/built
-        fi
-    # Outputs:
-    #   /tmp/robuild/result.json    - JSON output from the service.
-    #   /tmp/robuild/{ok,failed}    - status of the build (whether RC was 0).
-    #   /tmp/robuild/built          - the output result from the build.
-    #   /tmp/robuild/rc             - the value of the return code (decimal string)
-    #   /tmp/robuild/messages.txt   - system messages
-    #   /tmp/robuild/output.txt     - output from the build
+      - name: Obtain prerequisite build tool
+        run: |
+          # Fetch the build client
+          curl -s -L -o riscos-build-online https://github.com/gerph/robuild-client/releases/download/v0.07/riscos-build-online && chmod +x riscos-build-online
 
-    # Another drop in, which uses that information to show the results
-    - name: Did it work?
-      run: |
-        echo "System messages:"
-        sed 's/^/  /' < /tmp/robuild/messages.txt
-        echo
-        echo "Build output:"
-        sed 's/^/  /' < /tmp/robuild/output.txt
-        echo
-        if [ ! -f /tmp/robuild/ok ] ; then
-            echo "FAILED! Aborting"
-            exit 1
-        fi
+      - name: Build through build.riscos.online
+        run: |
+          # Zip up the source to send to robuild
+          zip -q9r /tmp/source-archive.zip * .robuild.yml
 
-    - name: Give the archive a versioned name
-      run: |
-        version=$(sed '/MajorVersion / ! d ; s/.*MajorVersion *"\(.*\)"/\1/' VersionNum)
-        echo This is version: $version
-        if [ -f /tmp/robuild/built ] ; then
-            cp /tmp/robuild/built "/tmp/robuild/LineEditor-$version.zip"
-        else
-            echo "No archive was built?"
-            exit 1
-        fi
+          # Send the archive file to build service (timeout of 60 seconds)
+          ./riscos-build-online -i /tmp/source-archive.zip -a off -t 60 -o /tmp/built
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: LineEditor
-        path: /tmp/robuild/LineEditor*.zip
-      # The artifact that is downloadable from the Actions is actually a zip of the artifacts
-      # that we supply. So it will be a regular Zip file containing a RISC OS Zip file.
+      - name: Give the output a versioned name
+        id: version
+        run: |
+          if [[ -f VersionNum ]] ; then
+              version=$(sed '/MajorVersion / ! d ; s/.*MajorVersion *"\(.*\)"/\1/' VersionNum)
+          else
+              version=$(git rev-parse --short HEAD)
+          fi
+          echo "This is version: $version"
+          leafname="LineEditor-$version.zip"
+          if [ -f /tmp/built,a91 ] ; then
+              cp /tmp/built,a91 "LineEditor-$version.zip"
+          else
+              echo "No archive was built?"
+              exit 1
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "leafname=$leafname" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RISCOS-build
+          path: ${{ steps.version.outputs.leafname }}
+        # The artifact that is downloadable from the Actions is actually a zip of the artifacts
+        # that we supply. So it will be a regular Zip file containing a RISC OS Zip file.
+
+  # The release only triggers when the thing that was pushed was a tag starting with 'v'
+  release:
+    needs: build-riscos
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download built RISC OS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: RISCOS-build
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: false
+          draft: true
+          artifacts: "${{ needs.build-riscos.outputs.leafname }}"
+          artifactContentType: application/zip


### PR DESCRIPTION
The actions we use have been updated to the recent versions, and we now use riscos-build-online rather than the JSON version.

The release process is also handled so tagging with `v*` will create a release. That should make it easier if you want to do releases through GitHub in the future.
