### PR TITLE
Ensure that the Release archive only contains what we want.

### DIFF
--- a/!!Release,feb
+++ b/!!Release,feb
@@ -6,5 +6,8 @@ Copy <Obey$Dir>.* <Obey$Dir>.Release.* ~C~RQ
 Delete <Obey$Dir>.Release.!!Release
 Delete <Obey$Dir>.Release.KeyLib
 Delete <Obey$Dir>.Release.README/md
+Delete <Obey$Dir>.Release./robuild/yml
+IfThere <Obey$Dir>.Release._source_ Then Wipe <Obey$Dir>.Release._source_ ~CFR
+Remove <Obey$Dir>.Release.riscos-build-online
 
 Echo Release successfully built.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           # Zip up the source to send to robuild
           zip -q9r /tmp/source-archive.zip * .robuild.yml
+          zip -d /tmp/source-archive.zip riscos-build-online
 
           # Send the archive file to build service (timeout of 60 seconds)
           ./riscos-build-online -i /tmp/source-archive.zip -a off -t 60 -o /tmp/built


### PR DESCRIPTION
The release archive had been created with the _source_ files, the .robuild.yml and the riscos-build-online tool. This wasn't right and shouldn't be part of the archive.